### PR TITLE
Support for Python 3.7 and better Python tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,11 @@ BLOOM_TEST_OBJ = $(BLOOM_TEST:.cc=.o)
 
 LIBSDBF=libsdbf.a
 
-all: boost stream 
+all: proto boost stream 
 
-debug: boost stream 
+debug: proto boost stream 
 
-cygwin: boost stream
+cygwin: proto boost stream
 
 install: boost man 
 	mkdir -p $(INSTDIR)
@@ -66,16 +66,14 @@ man/sdhash-srv.1:
 man/sdhash-cli.1:
 	pod2man -c "" -r "" man/sdhash-cli.pod > man/sdhash-cli.1
 
-swig-py: boost swig/python/sdbf_wrap.o swig/python/_sdbf_class.so 
+swig-py: proto boost swig/python/sdbf_wrap.o swig/python/_sdbf_class.so 
 swig-win-py: boost swig/python/sdbf_wrap.o swig/python/_sdbf_class.dll 
 
 swig/python/sdbf_wrap.o: sdbf.i $(LIBSDBF)
 	swig -c++ -python -py3 swig/python/sdbf.i
-	#g++ -std=c++0x -fPIC -c swig/python/sdbf_wrap.cxx -o swig/python/sdbf_wrap.o -I/usr/include/python2.7
 	g++ -std=c++0x -fPIC -c swig/python/sdbf_wrap.cxx -o swig/python/sdbf_wrap.o -I/usr/include/python3.7
 
 swig/python/_sdbf_class.so: swig/python/sdbf_wrap.o $(LIBSDBF)
-	#g++ -shared swig/python/sdbf_wrap.o -fopenmp -L./external/stage/lib -Wl,--whole-archive -lboost_system -lboost_filesystem -lboost_thread -Wl,--no-whole-archive -lpython2.7 libsdbf.a -o swig/python/_sdbf_class.so -lcrypto -lpthread 
 	g++ -shared swig/python/sdbf_wrap.o -fopenmp -L./external/stage/lib -Wl,--whole-archive -lboost_system -lboost_filesystem -lboost_thread -Wl,--no-whole-archive -lpython3.7m libsdbf.a -o swig/python/_sdbf_class.so -lcrypto -lpthread 
 
 sdbf.i:
@@ -89,8 +87,10 @@ stream: $(SDHASH_OBJ) $(LIBSDBF)
 bloom-test: $(BLOOM_TEST_OBJ) $(LIBSDBF)
 	$(LD) $(BLOOM_TEST_OBJ) $(LIBSDBF) -o bloom-test $(LDFLAGS) 
 
+proto:
+	protoc blooms.proto --cpp_out sdbf/
+
 boost: 
-	#cd external ; ./bootstrap.sh --with-python=python2 ; ./b2 link=static cxxflags='-fPIC -std=c++0x' ; cd -
 	cd external ; ./bootstrap.sh --with-python=python3 ; ./b2 link=static cxxflags=' -fPIC -std=c++0x' ; cd -
 
 server:

--- a/Makefile
+++ b/Makefile
@@ -70,11 +70,13 @@ swig-py: boost swig/python/sdbf_wrap.o swig/python/_sdbf_class.so
 swig-win-py: boost swig/python/sdbf_wrap.o swig/python/_sdbf_class.dll 
 
 swig/python/sdbf_wrap.o: sdbf.i $(LIBSDBF)
-	swig -c++ -python swig/python/sdbf.i
-	g++ -std=c++0x -fPIC -c swig/python/sdbf_wrap.cxx -o swig/python/sdbf_wrap.o -I/usr/include/python2.7
+	swig -c++ -python -py3 swig/python/sdbf.i
+	#g++ -std=c++0x -fPIC -c swig/python/sdbf_wrap.cxx -o swig/python/sdbf_wrap.o -I/usr/include/python2.7
+	g++ -std=c++0x -fPIC -c swig/python/sdbf_wrap.cxx -o swig/python/sdbf_wrap.o -I/usr/include/python3.7
 
 swig/python/_sdbf_class.so: swig/python/sdbf_wrap.o $(LIBSDBF)
-	g++ -shared swig/python/sdbf_wrap.o -fopenmp -L./external/stage/lib -Wl,--whole-archive -lboost_system -lboost_filesystem -lboost_thread -Wl,--no-whole-archive -lpython2.7 libsdbf.a -o swig/python/_sdbf_class.so -lcrypto -lpthread 
+	#g++ -shared swig/python/sdbf_wrap.o -fopenmp -L./external/stage/lib -Wl,--whole-archive -lboost_system -lboost_filesystem -lboost_thread -Wl,--no-whole-archive -lpython2.7 libsdbf.a -o swig/python/_sdbf_class.so -lcrypto -lpthread 
+	g++ -shared swig/python/sdbf_wrap.o -fopenmp -L./external/stage/lib -Wl,--whole-archive -lboost_system -lboost_filesystem -lboost_thread -Wl,--no-whole-archive -lpython3.7m libsdbf.a -o swig/python/_sdbf_class.so -lcrypto -lpthread 
 
 sdbf.i:
 
@@ -88,7 +90,8 @@ bloom-test: $(BLOOM_TEST_OBJ) $(LIBSDBF)
 	$(LD) $(BLOOM_TEST_OBJ) $(LIBSDBF) -o bloom-test $(LDFLAGS) 
 
 boost: 
-	cd external ; ./bootstrap.sh --with-python=python2 ; ./b2 link=static cxxflags='-fPIC -std=c++0x' ; cd -
+	#cd external ; ./bootstrap.sh --with-python=python2 ; ./b2 link=static cxxflags='-fPIC -std=c++0x' ; cd -
+	cd external ; ./bootstrap.sh --with-python=python3 ; ./b2 link=static cxxflags=' -fPIC -std=c++0x' ; cd -
 
 server:
 	make -C ./sdhash-server -f Makefile

--- a/Makefile
+++ b/Makefile
@@ -71,10 +71,10 @@ swig-win-py: boost swig/python/sdbf_wrap.o swig/python/_sdbf_class.dll
 
 swig/python/sdbf_wrap.o: sdbf.i $(LIBSDBF)
 	swig -c++ -python -py3 swig/python/sdbf.i
-	g++ -std=c++0x -fPIC -c swig/python/sdbf_wrap.cxx -o swig/python/sdbf_wrap.o -I/usr/include/python3.7
+	g++ -std=c++0x -fPIC -c swig/python/sdbf_wrap.cxx -o swig/python/sdbf_wrap.o -I$(shell python3 -c "import sysconfig; print(sysconfig.get_path('include'))")
 
 swig/python/_sdbf_class.so: swig/python/sdbf_wrap.o $(LIBSDBF)
-	g++ -shared swig/python/sdbf_wrap.o -fopenmp -L./external/stage/lib -Wl,--whole-archive -lboost_system -lboost_filesystem -lboost_thread -Wl,--no-whole-archive -lpython3.7m libsdbf.a -o swig/python/_sdbf_class.so -lcrypto -lpthread 
+	g++ -shared swig/python/sdbf_wrap.o -fopenmp -L./external/stage/lib -Wl,--whole-archive -lboost_system -lboost_filesystem -lboost_thread -Wl,--no-whole-archive -L$(shell python3 -c "import sysconfig; print(sysconfig.get_config_var('LIBDIR'))") -lpython3 libsdbf.a -o swig/python/_sdbf_class.so -lcrypto -lpthread
 
 sdbf.i:
 

--- a/blooms.proto
+++ b/blooms.proto
@@ -1,3 +1,5 @@
+syntax = "proto2"; 
+
 package blooms;
 
 message BloomFilter {

--- a/external/bootstrap.sh
+++ b/external/bootstrap.sh
@@ -277,7 +277,7 @@ if test "x$flag_no_python" = x; then
 
     if test "x$PYTHON_ROOT" = x; then
         echo -n "Detecting Python root... "
-        PYTHON_ROOT=`$PYTHON -c "import sys; print sys.prefix"`
+        PYTHON_ROOT=`$PYTHON -c "import sys; print(sys.prefix)"`
         echo $PYTHON_ROOT
     fi    
 fi

--- a/sdbf/sdbf_class.h
+++ b/sdbf/sdbf_class.h
@@ -42,7 +42,9 @@ public:
     ~sdbf(); 
 
     /// object name
-    const char *name();  
+    //const char *name(); 
+    string name() const;
+
     /// object size
     uint64_t size();  
     /// source object size
@@ -101,7 +103,7 @@ private:
     string index_results;
         
     // from the C structure 
-    char *hashname;          // name (usually, source file)
+    string hashname;          // name (usually, source file)
     uint32_t  bf_count;      // Number of BFs
     uint32_t  bf_size;       // BF size in bytes (==m/8)
     uint32_t  hash_count;    // Number of hash functions used (k)

--- a/sdbf/sdbf_core.cc
+++ b/sdbf/sdbf_core.cc
@@ -351,7 +351,7 @@ sdbf::sdbf_score( sdbf *sdbf_1, sdbf *sdbf_2, uint32_t sample) {
     if( (bf_count_1 > sdbf_2->bf_count) ||
         (bf_count_1 == sdbf_2->bf_count && 
             ((get_elem_count( sdbf_1, bf_count_1-1) > get_elem_count( sdbf_2, sdbf_2->bf_count-1)) ||
-              strcmp( (char*)sdbf_1->hashname, (char*)sdbf_2->hashname) > 0 ))) {
+              strcmp( (char*)sdbf_1->hashname.c_str(), (char*)sdbf_2->hashname.c_str()) > 0 ))) {
             sdbf *tmp = sdbf_1;
             sdbf_1 = sdbf_2;
             sdbf_2 = tmp;

--- a/swig/python/sdbf.i
+++ b/swig/python/sdbf.i
@@ -5,12 +5,12 @@
 #include "../../sdbf/sdbf_defines.h"
 #include <stdint.h>
 #include <stdio.h>
-
 %}
 
 #define KB 1024
 %include "cpointer.i"
 %include "std_string.i"
+%include "typemaps.i"
 
 %pointer_functions(int, intp);
 
@@ -44,16 +44,18 @@ public:
     /// to read a formatted sdbf from string
     sdbf(const std::string& str); 
     /// to create new from a single file
-    sdbf(const char *filename, uint32_t dd_block_size); 
+    sdbf(const char *name, uint32_t dd_block_size); 
     /// to create by reading from an open stream
     sdbf(const char *name, std::istream *ifs, uint32_t dd_block_size, uint64_t msize, index_info *info) ; 
     /// to create from a c-string
+    %typemap(in) (char *str) { $1 = PyBytes_AsString($input); };
+    %typemap(typecheck) (char *str) { $1 = PyBytes_Check($input) ? 1 : 0; }
     sdbf(const char *name, char *str, uint32_t dd_block_size, uint64_t length, index_info *info);
     /// destructor
     ~sdbf(); 
 
     /// object name
-    const char *name();  
+    std::string name() const;
     /// object size
     uint64_t size();  
     /// source object size


### PR DESCRIPTION
This PR provides support for Python 3.7 via swig and builds out a set of Python unittests. 

I just want to call out a seemingly aggressive part of this change, where I've changed `sdbf::sdbf.hashname` to a `string` from a `char *` and `sdbf::sdbf.name()` to return a `string` from a `const char *`. I believe this was necessary due to swig's object management as in the original arrangement `sdbf_object.name()` would reference free'ed memory. I was unable to find an appropriate swig declarative that would work around this. 